### PR TITLE
Add m1 macos binary

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,10 +44,6 @@ jobs:
           name: OS specific binaries
           path: dist
 
-      - name: Include M1 build
-        run: |
-          mv ./build/osx/tiktoken-node.darwin-arm64.node ./dist/osx/
-
   deploy:
     # prevents this action from running on forks or pull requests
     if: ${{ github.repository == 'ceifa/tiktoken-node' && github.event_name == 'push' }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
 /dist
+!/dist/tiktoken-node.darwin-arm64.node
 node_modules
 Cargo.lock


### PR DESCRIPTION
Add the binary for M1 macOS to `./dist` directory since it can't be built by the github actions runners.

Remove step to copy the M1 macOS binary over to the `dist` directory since it's already there.